### PR TITLE
Fixed missing CamelCase preventing building on case sensitive filesystems.

### DIFF
--- a/include/knoxcrypt/FileBlock.hpp
+++ b/include/knoxcrypt/FileBlock.hpp
@@ -30,7 +30,7 @@
 #include "knoxcrypt/ContainerImageStream.hpp"
 #include "knoxcrypt/CoreIO.hpp"
 #include "knoxcrypt/OpenDisposition.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 
 #include <vector>

--- a/include/knoxcrypt/detail/DetailFileBlock.hpp
+++ b/include/knoxcrypt/detail/DetailFileBlock.hpp
@@ -30,7 +30,7 @@
 
 #include "knoxcrypt/CoreIO.hpp"
 #include "knoxcrypt/ContainerImageStream.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 
 #include <iostream>
 #include <stdint.h>

--- a/include/test/ContentFolderTest.hpp
+++ b/include/test/ContentFolderTest.hpp
@@ -30,11 +30,11 @@
 #include "knoxcrypt/CoreIO.hpp"
 #include "knoxcrypt/File.hpp"
 #include "knoxcrypt/ContentFolder.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 #include "test/SimpleTest.hpp"
 #include "test/TestHelpers.hpp"
-#include "utility/Makeknoxcrypt.hpp"
+#include "utility/MakeKnoxCrypt.hpp"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/include/test/FileBlockTest.hpp
+++ b/include/test/FileBlockTest.hpp
@@ -30,11 +30,11 @@
 #include "knoxcrypt/FileBlock.hpp"
 #include "knoxcrypt/FileBlockException.hpp"
 #include "knoxcrypt/OpenDisposition.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 #include "test/SimpleTest.hpp"
 #include "test/TestHelpers.hpp"
-#include "utility/Makeknoxcrypt.hpp"
+#include "utility/MakeKnoxCrypt.hpp"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/include/test/FileDeviceTest.hpp
+++ b/include/test/FileDeviceTest.hpp
@@ -31,10 +31,10 @@
 #include "knoxcrypt/FileDevice.hpp"
 #include "knoxcrypt/FileStreamPtr.hpp"
 #include "knoxcrypt/OpenDisposition.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "test/SimpleTest.hpp"
 #include "test/TestHelpers.hpp"
-#include "utility/Makeknoxcrypt.hpp"
+#include "utility/MakeKnoxCrypt.hpp"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/include/test/FileTest.hpp
+++ b/include/test/FileTest.hpp
@@ -29,11 +29,11 @@
 #include "knoxcrypt/ContainerImageStream.hpp"
 #include "knoxcrypt/File.hpp"
 #include "knoxcrypt/FileEntryException.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 #include "test/SimpleTest.hpp"
 #include "test/TestHelpers.hpp"
-#include "utility/Makeknoxcrypt.hpp"
+#include "utility/MakeKnoxCrypt.hpp"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/include/test/TestHelpers.hpp
+++ b/include/test/TestHelpers.hpp
@@ -31,7 +31,7 @@
 #include "cryptostreampp/Algorithms.hpp"
 #include "knoxcrypt/CoreIO.hpp"
 #include "knoxcrypt/FileBlockBuilder.hpp"
-#include "knoxcrypt/knoxcryptException.hpp"
+#include "knoxcrypt/KnoxCryptException.hpp"
 #include "utility/MakeKnoxCrypt.hpp"
 
 #include <boost/filesystem/path.hpp>

--- a/include/utility/MakeKnoxCrypt.hpp
+++ b/include/utility/MakeKnoxCrypt.hpp
@@ -33,7 +33,7 @@
 #include "knoxcrypt/FileBlock.hpp"
 #include "knoxcrypt/FileBlockBuilder.hpp"
 #include "knoxcrypt/CompoundFolder.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 #include "utility/EventType.hpp"
 #include "utility/PassHasher.hpp"

--- a/src/knoxcrypt/ContentFolder.cpp
+++ b/src/knoxcrypt/ContentFolder.cpp
@@ -29,7 +29,7 @@
 #include "knoxcrypt/CompoundFolder.hpp"
 #include "knoxcrypt/ContainerImageStream.hpp"
 #include "knoxcrypt/ContentFolder.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFolder.hpp"
 
 #include <algorithm>

--- a/src/knoxcrypt/File.cpp
+++ b/src/knoxcrypt/File.cpp
@@ -31,7 +31,7 @@
 #include "knoxcrypt/FileBlockBuilder.hpp"
 #include "knoxcrypt/FileBlockIterator.hpp"
 #include "knoxcrypt/FileEntryException.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 #include "knoxcrypt/detail/DetailFileBlock.hpp"
 
 #include <stdexcept>

--- a/src/knoxcrypt/FileBlockBuilder.cpp
+++ b/src/knoxcrypt/FileBlockBuilder.cpp
@@ -28,7 +28,7 @@
 
 #include "knoxcrypt/FileBlockBuilder.hpp"
 #include "knoxcrypt/ContainerImageStream.hpp"
-#include "knoxcrypt/detail/Detailknoxcrypt.hpp"
+#include "knoxcrypt/detail/DetailKnoxCrypt.hpp"
 
 namespace knoxcrypt
 {


### PR DESCRIPTION
This pull request corrects several includes to CamelCase, so that the compiler can find the files on case sensitive filesystems.